### PR TITLE
Handle www subdomains correctly

### DIFF
--- a/core/crawler.py
+++ b/core/crawler.py
@@ -50,7 +50,8 @@ class SEOCrawler:
         
         url_config = self.config.get('filters', {})
         self.url_manager = create_url_manager('default', domain, url_config)
-        
+        self.url_manager.set_base_domain(start_url)
+
         self.url_manager.add_url(start_url, depth=0)
         
         self.start_time = time.time()
@@ -288,7 +289,8 @@ class SmartSEOCrawler(SEOCrawler):
         url_config = self.config.get('filters', {})
         url_config['priority_patterns'] = self.priority_patterns
         self.url_manager = create_url_manager('smart', domain, url_config)
-        
+        self.url_manager.set_base_domain(start_url)
+
         self.url_manager.add_url(start_url, depth=0, priority=True)
         
         self.start_time = time.time()
@@ -313,7 +315,8 @@ class BatchSEOCrawler(SEOCrawler):
         url_config = self.config.get('filters', {})
         url_config['batch_size'] = self.batch_size
         self.url_manager = create_url_manager('batch', domain, url_config)
-        
+        self.url_manager.set_base_domain(start_url)
+
         self.url_manager.add_url(start_url, depth=0)
         
         self.start_time = time.time()

--- a/core/url_manager.py
+++ b/core/url_manager.py
@@ -28,7 +28,10 @@ class URLManager:
     
     def set_base_domain(self, url):
         """Define o domínio base a partir de uma URL"""
-        self.base_domain = urlparse(url).netloc
+        domain = urlparse(url).netloc.lower()
+        if domain.startswith("www."):
+            domain = domain[4:]
+        self.base_domain = domain
     
     def normalize_url(self, url, base_url=None):
         """🔥 CORREÇÃO: Normalização robusta anti-duplicação"""
@@ -43,12 +46,15 @@ class URLManager:
                 url = urljoin(base_url, url)
             
             parsed = urlparse(url)
-            
+
             # Validações básicas
             if parsed.scheme not in ['http', 'https']:
                 return None
-            
-            if self.base_domain and parsed.netloc != self.base_domain:
+
+            domain = parsed.netloc.lower()
+            if domain.startswith("www."):
+                domain = domain[4:]
+            if self.base_domain and domain != self.base_domain:
                 return None
             
             # 🔥 NORMALIZAÇÃO ANTI-DUPLICAÇÃO


### PR DESCRIPTION
## Summary
- strip `www.` when setting base domain
- compare domains without `www.` when normalizing URLs
- ensure crawlers reset base domain using the normalized form

## Testing
- `python -m py_compile core/url_manager.py core/crawler.py`
- `pytest -q`
- `python - <<'PY'
import sys
sys.path.append('core')
import url_manager as umod
u = umod.URLManager()
u.set_base_domain('https://www.example.com')
urls = ['https://www.example.com','https://example.com/about','https://www.example.com/contact','https://example.com/other']
for url in urls:
    r = u.add_url(url)
    print(url, '->', r)
print('urls_to_process:', [x[0] for x in u.urls_to_process])
PY`

------
https://chatgpt.com/codex/tasks/task_e_6848c09508b4832ab2fe817cedc6eb82